### PR TITLE
Added support to provide data using url queryparams

### DIFF
--- a/src/Invoice.js
+++ b/src/Invoice.js
@@ -1,19 +1,21 @@
-import React from 'react';
 import moment from 'moment';
+import React from 'react';
+import { getInvoiceDataFromURL } from './url';
 
 import './Invoice.css';
 
-class Invoice extends React.PureComponent {
+const urldata = getInvoiceDataFromURL();
 
+class Invoice extends React.PureComponent {
   getInvoiceNumber = () => {
-    const value = localStorage.getItem('number') || 'INV-1';
+    const value = urldata.invNumber || localStorage.getItem('number') || 'INV-1';
     document.title = `Invoice ${value}`;
     return value;
-  }
+  };
 
   state = {
-    date: localStorage.getItem('date') || moment().format('MMM D, YYYY'),
-    dueDate: localStorage.getItem('dueDate') || moment().format('MMM D, YYYY'),
+    date: urldata.date || localStorage.getItem('date') || moment().format('MMM D, YYYY'),
+    dueDate: urldata.dueDate || localStorage.getItem('dueDate') || moment().format('MMM D, YYYY'),
     number: this.getInvoiceNumber()
   }
 

--- a/src/Table.js
+++ b/src/Table.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import GenerateRows from './GenerateRows';
+import { getRowsFromURL } from './url';
 
 import './Table.css';
 
-class Table extends React.PureComponent {
+const urlRows = getRowsFromURL();
 
+class Table extends React.PureComponent {
   getRowList = () => {
     const rows = localStorage.getItem('rows');
     if (rows) {
@@ -19,7 +21,7 @@ class Table extends React.PureComponent {
   }
 
   state = {
-    rows: this.getRowList(),
+    rows: urlRows.length > 0 ? urlRows : this.getRowList(),
     showGenerateRowsModal: false
   }
 

--- a/src/url.js
+++ b/src/url.js
@@ -1,0 +1,48 @@
+import moment from 'moment';
+
+export function getQueryParams() {
+  return Object.fromEntries(new URL(window.location.href).searchParams);
+}
+
+const qp = getQueryParams();
+
+/** Get Invoice data (number, date, due date) from the URL querystring */
+export function getInvoiceDataFromURL() {
+  const invNumber = qp.number ? `INV-${qp.number}` : undefined;
+  const date = qp.date
+    ? moment(qp.date, 'YYYY-MM-DD').format('MMM D, YYYY')
+    : undefined;
+  const dueDate = qp.duedate
+    ? moment(qp.duedate, 'YYYY-MM-DD').format('MMM D, YYYY')
+    : undefined;
+
+  return { invNumber, date, dueDate };
+}
+
+/**
+ * Get the rows (description + price) from the URL querystring.
+ *
+ * - The descripcion and price of each row must be separated by "|"
+ * - The different rows must be separated by "||"
+ *
+ */
+export function getRowsFromURL() {
+  const urlItems = qp.rows;
+  if (!urlItems) return [];
+
+  const rows = [];
+
+  for (const line of urlItems.split('||')) {
+    const [name, value] = line.split('|');
+    const price = parseFloat(value);
+
+    if (name && price && !isNaN(price))
+      rows.push({ name, price, key: random() });
+  }
+
+  return rows;
+}
+
+function random() {
+  return `${Date.now()}${Math.floor(Math.random() * 100000)}`;
+}


### PR DESCRIPTION
This PR adds support to preload the invoice from an external source using the URL query params:

- `number`: Invoice number. For example if 10 -> INV-10
- `date`: Invoice date in **YYYY-MM-DD** format
- `duedate`: Invoice due date in **YYYY-MM-DD** format
- `rows`: String with the list of rows. Each row has the following format `<description>|<price>`. Then the rows are separated by two `|` -> `<row>||<row>||<row>`

All the parameters are **optional**. If any of them are missing, the default behavior is used (localstorage + default fallback)